### PR TITLE
feat: verify signature util

### DIFF
--- a/packages/ethers/src/contracts/IERC1271.ts
+++ b/packages/ethers/src/contracts/IERC1271.ts
@@ -1,0 +1,14 @@
+import type { Call, Contract } from '@enzymefinance/ethers';
+import { contract } from '@enzymefinance/ethers';
+import type { BigNumber, BigNumberish } from 'ethers';
+
+// prettier-ignore
+interface IERC1271 extends Contract<IERC1271> {
+  isValidSignature: Call<(_hash: BigNumberish, _signature: BigNumberish) => BigNumber, IERC1271>
+  }
+
+export const IERC1271 = contract<IERC1271>()`
+function isValidSignature(uint256 _hash, uint256 memory _signature) view returns (uint16)
+  `;
+
+// Returns 0x1626ba7e if signature is valid

--- a/packages/ethers/src/index.ts
+++ b/packages/ethers/src/index.ts
@@ -10,3 +10,4 @@ export * from './utils/resolveArguments';
 export * from './utils/ensureEvent';
 export * from './utils/ensureInterface';
 export * from './utils/extractEvent';
+export * from './utils/verifySignature';

--- a/packages/ethers/src/utils/verifySignature.ts
+++ b/packages/ethers/src/utils/verifySignature.ts
@@ -1,0 +1,29 @@
+import { BigNumber, utils } from 'ethers';
+
+import { IERC1271 } from '../contracts/IERC1271';
+import { sameAddress } from './sameAddress';
+
+interface VerifySignatureProps {
+  walletAddress: string;
+  message: string | utils.Bytes;
+  signature: string;
+}
+
+export async function verifySignature({ walletAddress, message, signature }: VerifySignatureProps): Promise<boolean> {
+  try {
+    const bytecode = await provider.getCode(walletAddress);
+    const isSmartContract = bytecode && utils.hexStripZeros(bytecode) !== '0x';
+    if (isSmartContract) {
+      const hash = utils.keccak256(message);
+      const contract = new IERC1271(walletAddress, provider);
+      const result = await contract.isValidSignature(hash, signature);
+      // Per https://eips.ethereum.org/EIPS/eip-1271
+      return result === BigNumber.from(0x1626ba7e);
+    } else {
+      const recoveredAddress = utils.verifyMessage(message, signature);
+      return sameAddress(recoveredAddress, walletAddress);
+    }
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
This PR adds a `verifySignature` util that handles both normal ETH addresses and smart contract wallets like argent (given that they handle the ERC1271 standard)